### PR TITLE
Customer account shows error after refresh when login

### DIFF
--- a/src/api/server/ajaxRouter.js
+++ b/src/api/server/ajaxRouter.js
@@ -245,7 +245,7 @@ ajaxRouter.post('/customer-account', async (req, res, next) => {
 	if (req.body.token) {
 		customerData.token = AuthHeader.decodeUserLoginAuth(req.body.token);
 		if (customerData.token.userId !== undefined) {
-			const userId = null;
+			let userId = null;
 			try {
 				userId = JSON.stringify(customerData.token.userId).replace(/["']/g, '');
 			} catch (erro) {}


### PR DESCRIPTION
Shows incorrect data when you refresh customer account date, because userId is constant and cannot be updated in try {} catch {} block