### PR TITLE
Fix an error when returning from the product page

### DIFF
--- a/theme/src/components/header/index.js
+++ b/theme/src/components/header/index.js
@@ -142,7 +142,7 @@ export default class Header extends React.Component {
 	};
 
 	handleGoBack = () => {
-		this.closeAll();
+		this.setSiteState(state.SITE)
 		this.props.goBack();
 	};
 


### PR DESCRIPTION
fixed an error when returning from the product page.
refer to `Pablo` (@scamim) message in telegram chat: 
`hi mate, i found new bug in header, after last ur update. I cant close product. (Console: Uncaught TypeError: n.closeAll is not a function)`